### PR TITLE
feat: add recent currency pairs quick-access chips

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1314,6 +1314,102 @@ h1, h2, h3, h4, h5, h6, .font-display {
 }
 
 /* --------------------------------
+   Recent Pairs
+   -------------------------------- */
+.recent-pairs {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.recent-pairs::-webkit-scrollbar {
+  display: none;
+}
+
+.recent-pairs-label {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  font-weight: 500;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.recent-pairs-list {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
+}
+
+.recent-pair-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.75rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.recent-pair-chip:hover {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: white;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.recent-pair-chip:active {
+  transform: translateY(0);
+}
+
+.recent-pair-chip.active {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: white;
+}
+
+.recent-pair-chip.active .chip-arrow {
+  opacity: 1;
+}
+
+.recent-pair-chip .chip-arrow {
+  opacity: 0.6;
+  font-size: 0.65rem;
+}
+
+.recent-pair-chip:hover .chip-arrow {
+  opacity: 1;
+}
+
+/* Animation for new chips */
+@keyframes chip-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.8) translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateX(0);
+  }
+}
+
+.recent-pair-chip.new {
+  animation: chip-enter 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* --------------------------------
    Stats Cards
    -------------------------------- */
 .stats-container {

--- a/index.html
+++ b/index.html
@@ -167,6 +167,12 @@
         </div>
       </div>
     </div>
+    
+    <!-- Recent Pairs -->
+    <div id="recent-pairs" class="recent-pairs hidden">
+      <span class="recent-pairs-label">Recent:</span>
+      <div id="recent-pairs-list" class="recent-pairs-list"></div>
+    </div>
   </section>
 
   <!-- Loader -->


### PR DESCRIPTION
- Store last 5 viewed currency pairs in localStorage
- Render clickable chips below the currency selector
- One-click navigation to previously viewed pairs
- Auto-deduplicate when same pair is selected again
- Visual feedback with hover/active states and subtle animations
- Active pair chip highlighted with accent background
- Chips appear with staggered fade-in animation on load

Signed-off-by: Avish Jha <avish.j@protonmail.com>