### PR TITLE
fix: restore push trigger for db deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,12 @@
 name: Deploy Frontend
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'db/**'
   workflow_run:
-    workflows: ["CI", "Update Data"]
+    workflows: ["CI"]
     types:
       - completed
   workflow_dispatch:
@@ -18,9 +22,9 @@ jobs:
     timeout-minutes: 5
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (github.event.workflow_run.conclusion == 'success' &&
-       (github.event.workflow_run.head_branch == 'main' || 
-        github.ref == 'refs/heads/main'))
+       github.event.workflow_run.head_branch == 'main')
 
     permissions:
       contents: read


### PR DESCRIPTION
Signed-off-by: Avish Jha <avish.j@protonmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores automatic DB deploys when changes in db/ are merged to main. Adds a push trigger and tightens conditions so deploys run only when appropriate.

- **Bug Fixes**
  - Add push trigger for main with path filter db/**.
  - Limit workflow_run to CI only; drop "Update Data".
  - Update job condition to allow push events and only run on successful CI for main.

<sup>Written for commit 3f1f5fcda63b0ebd4677a4b3248fbf21a3bdd2d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined deployment workflow triggers to improve consistency by restricting deployes to main branch pushes affecting database files and successful CI completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->